### PR TITLE
Support allowing multiple notifiers to send out Notifications

### DIFF
--- a/lib/adhearsion/reporter.rb
+++ b/lib/adhearsion/reporter.rb
@@ -20,11 +20,12 @@ module Adhearsion
         api_key nil,                  desc: "The Airbrake/Errbit API key"
         url     "http://airbrake.io", desc: "Base URL for notification service"
         app_name "Adhearsion", desc: "Application name, used for reporting"
-        notifiers nil,
-          desc: "Collection of classes that will act as notifiers"
-        notifier Adhearsion::Reporter::AirbrakeNotifier,
-          desc: "The class that will act as the notifier. Built-in classes are Adhearsion::Reporter::AirbrakeNotifier and Adhearsion::Reporter::NewrelicNotifier",
-          transform: Proc.new { |v| const_get(v.to_s) }
+        notifiers [Adhearsion::Reporter::AirbrakeNotifier],
+          desc: "Collection of classes that will act as notifiers",
+          transform: Proc.new { |v| notifiers = v.split(','); notifiers = notifiers.each.map(&:to_s).map(&:const_get) }
+#        notifier Adhearsion::Reporter::AirbrakeNotifier,
+#          desc: "The class that will act as the notifier. Built-in classes are Adhearsion::Reporter::AirbrakeNotifier and Adhearsion::Reporter::NewrelicNotifier",
+#          transform: Proc.new { |v| const_get(v.to_s) }
         enable true, desc: "Whether to send notifications - set to false to disable all notifications globally (useful for testing)"
         excluded_environments [:development, :test], desc: "Skip reporting errors for the listed environments (comma delimited when set by environment variable", transform: Proc.new { |v| names = v.split(','); names = names.each.map &:to_sym }
         newrelic {
@@ -38,13 +39,12 @@ module Adhearsion
       end
 
       init :reporter do
-        Reporter.config.notifier.init
-        Events.register_callback(:exception) do |e, logger|
-          if not Reporter.config.notifiers
-            Reporter.config.notifier.instance.notify e
-          else
-            Reporter.config.notifiers.each do |notifier|
-              notifier.instance.notify e
+        if not Reporter.config.notifiers.nil?
+          notifiers = Reporter.config.notifiers
+          notifiers.each_with_index do |notifier, idx|
+            notifier.init
+            Events.register_callback(:exception) do |e, logger|
+              Reporter.config.notifiers[idx].instance.notify e
             end
           end
         end

--- a/lib/adhearsion/reporter.rb
+++ b/lib/adhearsion/reporter.rb
@@ -20,6 +20,8 @@ module Adhearsion
         api_key nil,                  desc: "The Airbrake/Errbit API key"
         url     "http://airbrake.io", desc: "Base URL for notification service"
         app_name "Adhearsion", desc: "Application name, used for reporting"
+        notifiers nil,
+          desc: "Collection of classes that will act as notifiers"
         notifier Adhearsion::Reporter::AirbrakeNotifier,
           desc: "The class that will act as the notifier. Built-in classes are Adhearsion::Reporter::AirbrakeNotifier and Adhearsion::Reporter::NewrelicNotifier",
           transform: Proc.new { |v| const_get(v.to_s) }
@@ -38,7 +40,13 @@ module Adhearsion
       init :reporter do
         Reporter.config.notifier.init
         Events.register_callback(:exception) do |e, logger|
-          Reporter.config.notifier.instance.notify e
+          if not Reporter.config.notifiers
+            Reporter.config.notifier.instance.notify e
+          else
+            Reporter.config.notifiers.each do |notifier|
+              notifier.instance.notify e
+            end
+          end
         end
       end
     end

--- a/lib/adhearsion/reporter/email_notifier.rb
+++ b/lib/adhearsion/reporter/email_notifier.rb
@@ -13,9 +13,9 @@ module Adhearsion
 
       def notify(ex)
         Pony.mail({
-          to: Adhearsion::Reporter.config.email.destination,
           subject: email_subject(ex),
-          body: exception_text(ex)
+          body: exception_text(ex),
+          from: hostname
         })
       end
 
@@ -36,7 +36,7 @@ module Adhearsion
       end
 
       def environment
-        Adhearsion.config.environment.to_s.upcase
+        Adhearsion.config.platform.environment.to_s.upcase
       end
 
       def hostname

--- a/lib/adhearsion/reporter/email_notifier.rb
+++ b/lib/adhearsion/reporter/email_notifier.rb
@@ -25,7 +25,7 @@ module Adhearsion
 
     private
       def email_subject(exception)
-        "[#{Adhearsion::Reporter.config.app_name}-#{environment}] Host: #{hostname} Exception: #{exception.class} (#{exception.message})"
+        "[#{Adhearsion::Reporter.config.app_name}-#{environment}] Exception: #{exception.class} (#{exception.message})"
       end
 
       def exception_text(exception)

--- a/lib/adhearsion/reporter/email_notifier.rb
+++ b/lib/adhearsion/reporter/email_notifier.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'pony'
+require 'socket'
 
 module Adhearsion
   class Reporter

--- a/lib/adhearsion/reporter/email_notifier.rb
+++ b/lib/adhearsion/reporter/email_notifier.rb
@@ -13,6 +13,7 @@ module Adhearsion
 
       def notify(ex)
         Pony.mail({
+          to: Adhearsion::Reporter.config.email.destination,
           subject: email_subject(ex),
           body: exception_text(ex)
         })
@@ -24,7 +25,7 @@ module Adhearsion
 
     private
       def email_subject(exception)
-        "[#{Adhearsion::Reporter.config.app_name}] Exception: #{exception.class} (#{exception.message})"
+        "[#{Adhearsion::Reporter.config.app_name}-#{environment}] Host: #{hostname} Exception: #{exception.class} (#{exception.message})"
       end
 
       def exception_text(exception)
@@ -32,6 +33,14 @@ module Adhearsion
         "\n\n#{exception.class} (#{exception.message}):\n" +
         exception.backtrace.join("\n") +
         "\n\n"
+      end
+
+      def environment
+        Adhearsion.config.environment.to_s.upcase
+      end
+
+      def hostname
+        Socket.gethostname
       end
     end
   end

--- a/spec/reporter_spec.rb
+++ b/spec/reporter_spec.rb
@@ -143,7 +143,7 @@ describe Adhearsion::Reporter do
 
       Timecop.freeze(time_freeze) do
         expect(Pony).to receive(:mail).at_least(:once).with({
-          subject: "[#{Adhearsion::Reporter.config.app_name}-#{environment}] Host: #{hostname} Exception: ExceptionClass (#{error_message})",
+          subject: "[#{Adhearsion::Reporter.config.app_name}-#{environment}] Exception: ExceptionClass (#{error_message})",
           body: "#{Adhearsion::Reporter.config.app_name} reported an exception at #{time_freeze.to_s}\n\nExceptionClass (#{error_message}):\n#{event_error.backtrace.join("\n")}\n\n",
           from: hostname
         })


### PR DESCRIPTION
@sfgeorge Whenever you have a chance to review this please.

CC: @rsuddeth

Pretty straight-forward change; replaces the notion of a single notifier with an array of registered Notifier classes. To preserve the original default behavior we list only a single notifier by default, AirbrakeNotifier, but we'll be overriding this in Phoenix itself to support the use of both Airbrake and Email.

The EmailNotifier was updated to include the environment from which we're sending out notifications (in the subject line). The host from which the notification originated from will be in the 'From:' field.
