### PR TITLE
feature DE3633-empty_backtrace_email_notifier

### DIFF
--- a/lib/adhearsion/reporter/email_notifier.rb
+++ b/lib/adhearsion/reporter/email_notifier.rb
@@ -30,9 +30,10 @@ module Adhearsion
       end
 
       def exception_text(exception)
+        backtrace = exception.backtrace || ["EMPTY BACKTRACE"]
         "#{Adhearsion::Reporter.config.app_name} reported an exception at #{Time.now.to_s}" +
         "\n\n#{exception.class} (#{exception.message}):\n" +
-        exception.backtrace.join("\n") +
+        backtrace.join("\n") +
         "\n\n"
       end
 


### PR DESCRIPTION
email_notifier: Provide text for exception_text when exception.backtrace is nil

@fractalis Can you review this for me?
